### PR TITLE
Added std::forward in order to respect move semantics in some methods.

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -474,7 +474,7 @@ class EntityManager : entityx::help::NonCopyable, public enable_shared_from_this
    */
   template <typename C, typename ... Args>
   ptr<C> assign(Entity::Id entity, Args && ... args) {
-    return assign<C>(entity, ptr<C>(new C(args ...)));
+    return assign<C>(entity, ptr<C>(new C(std::forward<Args>(args) ...)));
   }
 
   /**
@@ -630,7 +630,7 @@ ptr<C> Entity::assign(ptr<C> component) {
 template <typename C, typename ... Args>
 ptr<C> Entity::assign(Args && ... args) {
   assert(valid());
-  return manager_.lock()->assign<C>(id_, args ...);
+  return manager_.lock()->assign<C>(id_, std::forward<Args>(args) ...);
 }
 
 template <typename C>

--- a/entityx/Event.h
+++ b/entityx/Event.h
@@ -160,7 +160,7 @@ class EventManager : entityx::help::NonCopyable {
    */
   template <typename E, typename ... Args>
   void emit(Args && ... args) {
-    E event(args ...);
+    E event(std::forward<Args>(args) ...);
     auto sig = signal_for(E::family());
     sig->emit(static_cast<BaseEvent*>(&event));
   }

--- a/entityx/System.h
+++ b/entityx/System.h
@@ -12,6 +12,7 @@
 
 
 #include <unordered_map>
+#include <utility>
 #include <stdint.h>
 #include <cassert>
 #include "entityx/config.h"
@@ -108,7 +109,7 @@ class SystemManager : entityx::help::NonCopyable, public enable_shared_from_this
    */
   template <typename S, typename ... Args>
   ptr<S> add(Args && ... args) {
-    ptr<S> s(new S(args ...));
+    ptr<S> s(new S(std::forward<Args>(args) ...));
     add(s);
     return s;
   }


### PR DESCRIPTION
Previously, calls to the methods assign<C>(...), emit<E>(...), and add<S>(...)
would fail if constructor arguments relied upon move semantics.
