### PR TITLE
Add pkg-config source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,21 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/entityx/config.h
 )
 
+
+if (NOT WINDOWS OR CYGWIN)
+    set(entityx_libs -lentityx)
+
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/entityx.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/entityx.pc
+        )
+
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/entityx.pc
+        DESTINATION "lib/pkgconfig"
+        )
+endif()
+
 install(
     DIRECTORY "entityx"
     DESTINATION "include"

--- a/entityx.pc.in
+++ b/entityx.pc.in
@@ -1,0 +1,6 @@
+# entityx pkg-config source file
+
+Name: entityx
+Description: EntityX is an EC system that uses C++11 features to provide type-safe component management, event delivery, etc.
+Version: @ENTITYX_VERSION@
+Libs: @entityx_libs@


### PR DESCRIPTION
This allows you to use `pkg_search_module` in CMake to find entityx. Gets around needing a FindEntityX.cmake script. The entity.pc.in file is pretty barebones and could probably be more useful with configurable install prefix dirs, but this catches 99% of installs I would imagine.

Example:

```
include(FindPkgConfig)
pkg_search_module(ENTITYX REQUIRED entityx)

add_executable(some_game main.cpp)
target_link_libraries(some_game ENTITYX_LIBRARIES)
```
