### PR TITLE
Fix VS2013 compiler error in Entity_test.cc

### DIFF
--- a/entityx/Entity_test.cc
+++ b/entityx/Entity_test.cc
@@ -337,6 +337,10 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityDestroyedEvent") {
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentAddedEvent") {
   struct ComponentAddedEventReceiver
       : public Receiver<ComponentAddedEventReceiver> {
+
+    ComponentAddedEventReceiver()
+      : position_events(0), direction_events(0) {}
+
     void receive(const ComponentAddedEvent<Position> &event) {
       auto p = event.component;
       float n = static_cast<float>(position_events);
@@ -353,8 +357,8 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentAddedEvent") {
       direction_events++;
     }
 
-    int position_events = 0;
-    int direction_events = 0;
+    int position_events;
+    int direction_events;
   };
 
   ComponentAddedEventReceiver receiver;


### PR DESCRIPTION
Might be a weird compiler bug.
The compiler was throwing errors at me 

```
  Entity_test.cc
..\entityx\Entity_test.cc(361): error C2327: 'EntityManagerFixture::ev' : is not a type name, static, or enumerator
..\entityx\Entity_test.cc(361): error C2065: 'ev' : undeclared identifier
..\entityx\Entity_test.cc(361): error C2228: left of '.subscribe' must have class/struct/union
          type is 'unknown-type'
..\entityx\Entity_test.cc(362): error C2327: 'EntityManagerFixture::ev' : is not a type name, static, or enumerator
..\entityx\Entity_test.cc(362): error C2065: 'ev' : undeclared identifier
..\entityx\Entity_test.cc(362): error C2228: left of '.subscribe' must have class/struct/union
          type is 'unknown-type'
..\entityx\Entity_test.cc(370): error C2327: 'EntityManagerFixture::em' : is not a type name, static, or enumerator
..\entityx\Entity_test.cc(370): error C2065: 'em' : undeclared identifier
..\entityx\Entity_test.cc(370): error C2228: left of '.create' must have class/struct/union
          type is 'unknown-type'
```

Moving the `struct ComponentAddedEventReceiver` outside the test function or removing the `struct ComponentAddedEventReceiver`'s member default value fix it.
