### PR TITLE
Added CMake Find_Package script and debug suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(install_libs entityx)
 
 set(sources entityx/System.cc entityx/Event.cc entityx/Entity.cc entityx/help/Timer.cc entityx/help/Pool.cc)
 add_library(entityx STATIC ${sources})
+set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d)
 
 if (ENTITYX_BUILD_SHARED)
     message("-- Building shared libraries (-DENTITYX_BUILD_SHARED=0 to only build static librarires)")

--- a/cmake/FindEntityX.cmake
+++ b/cmake/FindEntityX.cmake
@@ -1,0 +1,28 @@
+﻿# Look for a version of EntityX on the local machine
+#
+# By default, this will look in all common places. If EntityX is built or
+# installed in a custom location, you're able to either modify the
+# CMakeCache.txt file yourself or simply pass the path to CMake using either the
+# environment variable `ENTITYX_ROOT` or the CMake define with the same name.
+
+set(ENTITYX_PATHS	${ENTITYX_ROOT}
+					$ENV{ENTITYX_ROOT}
+					~/Library/Frameworks
+					/Library/Frameworks
+					/usr/local
+					/usr
+					/sw
+					/opt/local
+					/opt/csw
+					/opt)
+
+find_path(ENTITYX_INCLUDE_DIR entityx/entityx.h PATH_SUFFIXES include PATHS ${ENTITYX_PATHS})
+find_library(ENTITYX_LIBRARY NAMES entityx PATH_SUFFIXES lib PATHS ${ENTITYX_PATHS})
+find_library(ENTITYX_LIBRARY_DEBUG NAMES entityx-d PATH_SUFFIXES lib PATHS ${ENTITYX_PATHS})
+mark_as_advanced(ENTITYX_INCLUDE_DIR ENTITYX_LIBRARY)
+
+if(ENTITYX_INCLUDE_DIR AND ENTITYX_LIBRARY)
+	set(ENTITYX_FOUND TRUE)
+else()
+	set(ENTITYX_FOUND FALSE)
+endif()


### PR DESCRIPTION
- This allows easy inclusion of EntityX in CMake projects using `Find_Package(EntityX)`.
- Also debug versions now use the `-d` suffix, no longer overwriting release builds (e.g. `entityx-d.lib` rather than `entityx.lib`).
