### PR TITLE
Add SystemManager::update_all() Method

### DIFF
--- a/entityx/System.cc
+++ b/entityx/System.cc
@@ -17,7 +17,7 @@ BaseSystem::Family BaseSystem::family_counter_;
 BaseSystem::~BaseSystem() {
 }
 
-void SystemManager::updateAll(TimeDelta dt) {
+void SystemManager::update_all(TimeDelta dt) {
   assert(initialized_ && "SystemManager::configure() not called");
   for (auto &pair : systems_) {
     pair.second->update(entity_manager_, event_manager_, dt);

--- a/entityx/System.h
+++ b/entityx/System.h
@@ -142,7 +142,18 @@ class SystemManager : entityx::help::NonCopyable {
     s->update(entity_manager_, event_manager_, dt);
   }
 
-  void updateAll(TimeDelta dt);
+  /**
+   * Call System::update() on all registered systems.
+   *
+   * The order which the registered systems are updated is arbitrary but consistent,
+   * meaning the order which they will be updated cannot be specified, but that order
+   * will stay the same as long no systems are added or removed.
+   *
+   * If the order in which systems update is important, use SystemManager::update()
+   * to manually specify the update order. EntityX does not yet support a way of
+   * specifying priority for update_all().
+   */
+  void update_all(TimeDelta dt);
 
   /**
    * Configure the system. Call after adding all Systems.

--- a/entityx/System_test.cc
+++ b/entityx/System_test.cc
@@ -117,7 +117,7 @@ TEST_CASE_METHOD(EntitiesFixture, "TestApplyAllSystems") {
   systems.add<CounterSystem>();
   systems.configure();
 
-  systems.updateAll(0.0);
+  systems.update_all(0.0);
   Position::Handle position;
   Direction::Handle direction;
   Counter::Handle counter;


### PR DESCRIPTION
_work for #74_
- Added an `updateAll()` method to the `SystemManager` that updates all systems in the manager.
- Added a test for `SystemManager::updateAll()`.
