### PR TITLE
Add System & EntitySystemManager

### DIFF
--- a/entityx/entity_system_manager.hh
+++ b/entityx/entity_system_manager.hh
@@ -1,0 +1,19 @@
+#pragma once
+#include "entityx.hh"
+#include "system.hh"
+
+namespace entityx {
+
+template <typename ... Cs>
+class EntitySystemManager {
+public:
+protected:
+  typedef entityx::Components<Cs...> Components;
+  typedef entityx::EntityX<Components, entityx::ColumnStorage<Components>> EntityManager;
+  template <typename T> using Component = typename EntityManager::template Component<T>;
+  using Entity = typename EntityManager::Entity;
+  
+  EntityManager entities_;
+  SystemManager<EntityManager> systems_ = SystemManager<EntityManager>(entities_);
+};
+} // namespace entityx

--- a/entityx/entity_system_manager.hh
+++ b/entityx/entity_system_manager.hh
@@ -1,19 +1,27 @@
 #pragma once
+
 #include "entityx.hh"
 #include "system.hh"
 
 namespace entityx {
 
-template <typename ... Cs>
+template<typename ... Cs>
 class EntitySystemManager {
 public:
+  ~EntitySystemManager() {
+    entities_.reset();
+    systems_.Reset();
+  }
+  virtual void Update(double dt) = 0;
 protected:
   typedef entityx::Components<Cs...> Components;
   typedef entityx::EntityX<Components, entityx::ColumnStorage<Components>> EntityManager;
-  template <typename T> using Component = typename EntityManager::template Component<T>;
+  template<typename T> using Component = typename EntityManager::template Component<T>;
   using Entity = typename EntityManager::Entity;
-  
+
+
+
   EntityManager entities_;
   SystemManager<EntityManager> systems_ = SystemManager<EntityManager>(entities_);
 };
-} // namespace entityx
+}

--- a/entityx/system.hh
+++ b/entityx/system.hh
@@ -94,6 +94,23 @@ public:
   }
 
   /**
+  * Call System::update() on all registered systems.
+  *
+  * The order which the registered systems are updated is arbitrary but consistent,
+  * meaning the order which they will be updated cannot be specified, but that order
+  * will stay the same as long no systems are added or removed.
+  *
+  * If the order in which systems update is important, use SystemManager::update()
+  * to manually specify the update order. EntityX does not yet support a way of
+  * specifying priority for update_all().
+  */
+  void UpdateAll(double dt) {
+    for (auto& pair : systems_) {
+      pair.second->Update(entity_manager_, dt);
+    }
+  }
+
+  /**
   * Call to remove all Systems from SystemManager.
   *
   * Automatically called in SystemManager destructor.

--- a/entityx/system.hh
+++ b/entityx/system.hh
@@ -1,0 +1,83 @@
+#pragma once
+#include <unordered_map>
+#include <cassert>
+#include <memory>
+#include <bits/stl_bvector.h>
+#include <typeindex>
+#include <typeinfo>
+
+namespace entityx {
+
+template <class EntityManager>
+class System {
+public:
+  virtual ~System() {}
+  virtual void Update(EntityManager& entity_manager, double dt) = 0;
+};
+
+template <class EntityManager>
+class SystemManager {
+public:
+  SystemManager(EntityManager& entity_manager) : entity_manager_(entity_manager) {}
+
+  /**
+  * Add a System to the SystemManager.
+  *
+  * Must be called before Systems can be used.
+  *
+  * eg.
+  * std::shared_ptr<MovementSystem> movement = entityx::make_shared<MovementSystem>();
+  * system.add(movement);
+  */
+  template <template <typename> class S>
+  void Add(std::shared_ptr<S<EntityManager>> system) {
+    //systems_.insert(std::make_pair(std::type_index(typeid(S<EntityManager>)), system));
+    systems_[std::type_index(typeid(S<EntityManager>))] = system;
+  }
+
+  /**
+  * Add a System to the SystemManager.
+  *
+  * Must be called before Systems can be used.
+  *
+  * eg.
+  * auto movement = system.add<MovementSystem>();
+  */
+  template <template <typename> class S, typename ... Args>
+  std::shared_ptr<S<EntityManager>> Add(Args && ... args) {
+    std::shared_ptr<S<EntityManager>> s(new S<EntityManager>(std::forward<Args>(args) ...));
+    Add(s);
+    return s;
+  }
+
+  /**
+  * Retrieve the registered System instance, if any.
+  *
+  *   std::shared_ptr<CollisionSystem> collisions = systems.system<CollisionSystem>();
+  *
+  * @return System instance or empty shared_std::shared_ptr<S>.
+  */
+  template <template <typename> class S>
+  std::shared_ptr<S<EntityManager>> system() {
+    //return systems_[std::type_index(typeid(S<EntityManager>))];
+    auto it = systems_.find(std::type_index(typeid(S<EntityManager>)));
+    assert(it != systems_.end());
+    return it == systems_.end() ? std::shared_ptr<S<EntityManager>>()
+				: std::shared_ptr<S<EntityManager>>(std::static_pointer_cast<S<EntityManager>>(it->second));
+  }
+
+  /**
+  * Call the System::update() method for a registered system.
+  */
+  template <template <typename> class S>
+  void Update(double dt) {
+    //assert(initialized_ && "SystemManager::configure() not called");
+    std::shared_ptr<S<EntityManager>> s = system<S<EntityManager>>();
+    s->update(entity_manager_, dt);
+  }
+
+private:
+  EntityManager& entity_manager_;
+  std::unordered_map<std::type_index, std::shared_ptr<System<EntityManager>>> systems_;
+};
+} // namespace entityx


### PR DESCRIPTION
Reimplemented support for a SystemManager. (Not sure if this is wanted.)
And added something similar to the EntityX class that was in quick.h, EntitySystemManager.

**Usage:**
```C++
class Level : public EntitySystemManager<Position, Velocity, Renderable> {
public:
  Level() {
    systems_.Add<MovementSystem>();
  }
  ~Level() {
    entities_.reset();
  }
  
  virtual void Update(float dt) {
    systems_.Update<MovementSystem>();
  }
};

// MovementSystem can be in a separate file
template <class EntityManager> 
class MovementSystem : public System<EntityManager> {
public:
  virtual void Update(EntityManager& entity_manager, double dt) {
    // Update entities normally with entity_manager.
  }
};
```

This allows a user to have multiple managers with different sets of components, while still reusing systems.