### PR TITLE
Entity::replace<Component> method.

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -135,6 +135,9 @@ public:
   template <typename C>
   ComponentHandle<C> assign_from_copy(const C &component);
 
+  template <typename C, typename ... Args>
+  ComponentHandle<C> replace(Args && ... args);
+
   template <typename C>
   void remove();
 
@@ -863,6 +866,19 @@ template <typename C>
 ComponentHandle<C> Entity::assign_from_copy(const C &component) {
   assert(valid());
   return manager_->assign<C>(id_, std::forward<const C &>(component));
+}
+
+template <typename C, typename ... Args>
+ComponentHandle<C> Entity::replace(Args && ... args) {
+  assert(valid());
+  auto handle = component<C>();
+  if (handle) {
+    *(handle.get()) = C(std::forward<Args>(args) ...);
+  }
+  else {
+    handle = manager_->assign<C>(id_, std::forward<Args>(args) ...);
+  }
+  return handle;
 }
 
 template <typename C>


### PR DESCRIPTION
Using `replace` avoids the client-side song and dance around assignment in cases where a component of the same type may already be assigned to the entity. This is a suggestion related to my mailing list question.