### PR TITLE
Fix code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Creating an entity is as simple as:
 ```c++
 #include <entityx/entityx.h>
 
-EntityX entityx;
+entityx::EntityX ex;
 
-entityx::Entity entity = entityx.entities.create();
+entityx::Entity entity = ex.entities.create();
 ```
 
 And destroying an entity is done with:


### PR DESCRIPTION
The current information is broken because while the second line uses the namespace, the first one doesn't. And in fact if the first one did work, it would redefine a variable to be the same identifier as the namespace itself.