### PR TITLE
Make Receiver inheritance public instead of implicitly private

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ class CollisionSystem : public System<CollisionSystem> {
 Objects interested in receiving collision information can subscribe to ``Collision`` events by first subclassing the CRTP class ``Receiver<T>``:
 
 ```c++
-struct DebugSystem : public System<DebugSystem>, Receiver<DebugSystem> {
+struct DebugSystem : public System<DebugSystem>, public Receiver<DebugSystem> {
   void configure(entityx::EventManager &event_manager) {
     event_manager.subscribe<Collision>(*this);
   }


### PR DESCRIPTION
Otherwise you get an error when trying to run the example.

/home/lemling/Dokumente/Proggen/BaconGameJam/bgj09/entityx/entityx/Event.h: In instantiation of ‘void entityx::EventManager::subscribe(Receiver&) [with E = PlayerInstrucionEvent; Receiver = MovementSystem]’:
/home/lemling/Dokumente/Proggen/BaconGameJam/bgj09/src/system_movement.hpp:17:58:   required from here
/home/lemling/Dokumente/Proggen/BaconGameJam/bgj09/entityx/entityx/Event.h:130:26: error: ‘entityx::BaseReceiver’ is an inaccessible base of ‘MovementSystem’
     BaseReceiver &base = receiver;