### PR TITLE
Fix size downcast warning on 64 bit builds.

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -495,9 +495,9 @@ class EntityManager : entityx::help::NonCopyable {
 
 
     Iterator begin() { return Iterator(manager_, mask_, 0, unpacker_); }
-    Iterator end() { return Iterator(manager_, mask_, manager_->capacity(), unpacker_); }
+    Iterator end() { return Iterator(manager_, mask_, static_cast<uint32_t>(manager_->capacity()), unpacker_); }
     const Iterator begin() const { return Iterator(manager_, mask_, 0, unpacker_); }
-    const Iterator end() const { return Iterator(manager_, mask_, manager_->capacity(), unpacker_); }
+    const Iterator end() const { return Iterator(manager_, mask_, static_cast<uint32_t>(manager_->capacity()), unpacker_); }
 
 
    private:


### PR DESCRIPTION
The number of entities is limited to 2^32 so capacity will never exceed that number, so this code is safe.