### PR TITLE
Generate seperate debug postfix dll for building in debug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if (ENTITYX_BUILD_SHARED)
         )
     set_target_properties(entityx_shared PROPERTIES
         OUTPUT_NAME entityx
+        DEBUG_POSTFIX -d
         VERSION ${ENTITYX_VERSION}
         SOVERSION ${ENTITYX_MAJOR_VERSION})
     list(APPEND install_libs entityx_shared)


### PR DESCRIPTION
#115 accidentally reverted #116. This puts it back in.