### PR TITLE
Pr uint64fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,20 +28,20 @@ include(CheckCXXSourceCompiles)
 
 # Default compiler args
 if (CMAKE_CXX_COMPILER_ID MATCHES "(GNU|.*Clang)")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wall -Wextra -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=sign-compare -std=c++11")
-	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL "-g -Os -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELEASE "-g -O2 -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wall -Wextra -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=sign-compare -std=c++11")
+    set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "-g -Os -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-g -O2 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL 'MSVC')
-	# /Zi - Produces a program database (PDB) that contains type information and symbolic debugging information for use with the debugger.
-	# /FS - Allows multiple cl.exe processes to write to the same .pdb file
-	# /DEBUG - Enable debug during linking
-	# /Od - Disables optimization
-	set(CMAKE_CXX_FLAGS_DEBUG "/Zi /FS /DEBUG /Od /MDd")
-	# /Ox - Full optimization
-	set(CMAKE_CXX_FLAGS_RELEASE "/Ox -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Zi /FS /DEBUG")
+    # /Zi - Produces a program database (PDB) that contains type information and symbolic debugging information for use with the debugger.
+    # /FS - Allows multiple cl.exe processes to write to the same .pdb file
+    # /DEBUG - Enable debug during linking
+    # /Od - Disables optimization
+    set(CMAKE_CXX_FLAGS_DEBUG "/Zi /FS /DEBUG /Od /MDd")
+    # /Ox - Full optimization
+    set(CMAKE_CXX_FLAGS_RELEASE "/Ox -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Zi /FS /DEBUG")
 endif()
 
 # if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -59,7 +59,7 @@ include(CheckCXX11Features.cmake)
 
 set(OLD_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 if ((MAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 check_cxx_source_compiles(
 "
@@ -99,7 +99,15 @@ macro(create_test TARGET_NAME SOURCE)
         ${ARGN}
         )
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "entityx/tests")
-    add_test(${TARGET_NAME} ${TARGET_NAME})
+
+    # Special case for benchmark tests
+    if (${TARGET_NAME} MATCHES .*benchmark.*)
+        if(ENTITYX_RUN_BENCHMARKS)
+            add_test(${TARGET_NAME} ${TARGET_NAME})
+        endif()
+    else()
+        add_test(${TARGET_NAME} ${TARGET_NAME})
+    endif()
 endmacro()
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -150,9 +158,9 @@ if (ENTITYX_BUILD_TESTING)
     create_test(system_test entityx/System_test.cc)
     create_test(tags_component_test entityx/tags/TagsComponent_test.cc)
     create_test(dependencies_test entityx/deps/Dependencies_test.cc)
+    create_test(benchmarks_test entityx/Benchmarks_test.cc)
     if (ENTITYX_RUN_BENCHMARKS)
         message("-- Running benchmarks")
-        create_test(benchmarks_test entityx/Benchmarks_test.cc)
     else ()
         message("-- Not running benchmarks (use -DENTITYX_RUN_BENCHMARKS=1 to enable)")
     endif ()

--- a/entityx/Benchmarks_test.cc
+++ b/entityx/Benchmarks_test.cc
@@ -6,11 +6,19 @@
 #include "entityx/help/Timer.h"
 #include "entityx/Entity.h"
 
-using namespace std;
-using namespace entityx;
-
 using std::uint64_t;
+using std::cout;
+using std::endl;
+using std::vector;
 
+using entityx::Receiver;
+using entityx::Component;
+using entityx::ComponentHandle;
+using entityx::Entity;
+using entityx::EntityCreatedEvent;
+using entityx::EntityDestroyedEvent;
+using entityx::EventManager;
+using entityx::EntityManager;
 
 struct AutoTimer {
   ~AutoTimer() {


### PR DESCRIPTION
Fixes #122 
- Enables building, but not running benchmark tests when BUILD_TESTING is enabled. 
- Fixes uint64_t ambigutity issue on compiling Benchmark_tests.cc on MSVC