### PR TITLE
Emit ComponentRemovedEvent<T> on Entity::destroy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ To that end Components are typically [POD types](http://en.wikipedia.org/wiki/Pl
 As an example, position and direction information might be represented as:
 
 ```c++
-struct Position : public entityx::Component<Position> {
+struct Position {
   Position(float x = 0.0f, float y = 0.0f) : x(x), y(y) {}
 
   float x, y;
 };
 
-struct Direction : public entityx::Component<Direction> {
+struct Direction {
   Direction(float x = 0.0f, float y = 0.0f) : x(x), y(y) {}
 
   float x, y;
@@ -224,7 +224,7 @@ As an example, we might want to implement a very basic collision system using ou
 First, we define the event type, which for our example is simply the two entities that collided:
 
 ```c++
-struct Collision : public entityx::Component<Collision> {
+struct Collision {
   Collision(entityx::Entity left, entityx::Entity right) : left(left), right(right) {}
 
   entityx::Entity left, right;

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ To that end Components are typically [POD types](http://en.wikipedia.org/wiki/Pl
 As an example, position and direction information might be represented as:
 
 ```c++
-struct Position {
+struct Position : public entityx::Component<Position> {
   Position(float x = 0.0f, float y = 0.0f) : x(x), y(y) {}
 
   float x, y;
 };
 
-struct Direction {
+struct Direction : public entityx::Component<Direction> {
   Direction(float x = 0.0f, float y = 0.0f) : x(x), y(y) {}
 
   float x, y;
@@ -224,7 +224,7 @@ As an example, we might want to implement a very basic collision system using ou
 First, we define the event type, which for our example is simply the two entities that collided:
 
 ```c++
-struct Collision {
+struct Collision : public entityx::Component<Collision> {
   Collision(entityx::Entity left, entityx::Entity right) : left(left), right(right) {}
 
   entityx::Entity left, right;
@@ -290,6 +290,7 @@ Several events are emitted by EntityX itself:
 - Event objects are destroyed after delivery, so references should not be retained.
 - A single class can receive any number of types of events by implementing a ``receive(const EventType &)`` method for each event type.
 - Any class implementing `Receiver` can receive events, but typical usage is to make `System`s also be `Receiver`s.
+- When an `Entity` is destroyed it will cause all of its components to be removed. This triggers `ComponentRemovedEvent`s to be triggered for each of its components. These events are triggered before the `EntityDestroyedEvent`.
 
 ### Manager (tying it all together)
 

--- a/entityx/ComponentHandle.h
+++ b/entityx/ComponentHandle.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012 Alec Thomas <alec@swapoff.org>
+ * All rights reserved.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution.
+ *
+ * Author: Alec Thomas <alec@swapoff.org>
+ */
+
+#pragma once
+
+namespace entityx {
+
+class EntityManager;
+
+/**
+ * A ComponentHandle<C> is a wrapper around an instance of a component.
+ *
+ * It provides safe access to components. The handle will be invalidated under
+ * the following conditions:
+ *
+ * - If a component is removed from its host entity.
+ * - If its host entity is destroyed.
+ */
+template <typename C, typename EM>
+class ComponentHandle {
+public:
+  typedef C ComponentType;
+
+  ComponentHandle() : manager_(nullptr) {}
+
+  bool valid() const;
+  operator bool() const;
+
+  C *operator -> ();
+  const C *operator -> () const;
+
+  C *get();
+  const C *get() const;
+
+  /**
+   * Remove the component from its entity and destroy it.
+   */
+  void remove();
+
+  bool operator == (const ComponentHandle<C> &other) const {
+    return manager_ == other.manager_ && id_ == other.id_;
+  }
+
+  bool operator != (const ComponentHandle<C> &other) const {
+    return !(*this == other);
+  }
+
+private:
+  friend class EntityManager;
+
+  ComponentHandle(EM *manager, Entity::Id id) :
+      manager_(manager), id_(id) {}
+
+  EM *manager_;
+  Entity::Id id_;
+};
+
+}

--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -27,12 +27,14 @@
 #include <utility>
 #include <vector>
 #include <type_traits>
- #include <functional>
+#include <functional>
 
 #include "entityx/help/Pool.h"
+#include "entityx/EntityClass.h"
 #include "entityx/config.h"
 #include "entityx/Event.h"
 #include "entityx/help/NonCopyable.h"
+#include "entityx/ComponentHandle.h"
 
 namespace entityx {
 
@@ -40,185 +42,6 @@ typedef std::uint32_t uint32_t;
 typedef std::uint64_t uint64_t;
 
 class EntityManager;
-
-
-template <typename C, typename EM = EntityManager>
-class ComponentHandle;
-
-
-
-/** A convenience handle around an Entity::Id.
- *
- * If an entity is destroyed, any copies will be invalidated. Use valid() to
- * check for validity before using.
- *
- * Create entities with `EntityManager`:
- *
- *     Entity entity = entity_manager->create();
- */
-class Entity {
-public:
-  struct Id {
-    Id() : id_(0) {}
-    explicit Id(uint64_t id) : id_(id) {}
-    Id(uint32_t index, uint32_t version) : id_(uint64_t(index) | uint64_t(version) << 32UL) {}
-
-    uint64_t id() const { return id_; }
-
-    bool operator == (const Id &other) const { return id_ == other.id_; }
-    bool operator != (const Id &other) const { return id_ != other.id_; }
-    bool operator < (const Id &other) const { return id_ < other.id_; }
-
-    uint32_t index() const { return id_ & 0xffffffffUL; }
-    uint32_t version() const { return id_ >> 32; }
-
-  private:
-    friend class EntityManager;
-
-    uint64_t id_;
-  };
-
-
-  /**
-   * Id of an invalid Entity.
-   */
-  static const Id INVALID;
-
-  Entity() = default;
-  Entity(EntityManager *manager, Entity::Id id) : manager_(manager), id_(id) {}
-  Entity(const Entity &other) = default;
-  Entity &operator = (const Entity &other) = default;
-
-  /**
-   * Check if Entity handle is invalid.
-   */
-  operator bool() const {
-    return valid();
-  }
-
-  bool operator == (const Entity &other) const {
-    return other.manager_ == manager_ && other.id_ == id_;
-  }
-
-  bool operator != (const Entity &other) const {
-    return !(other == *this);
-  }
-
-  bool operator < (const Entity &other) const {
-    return other.id_ < id_;
-  }
-
-  /**
-   * Is this Entity handle valid?
-   *
-   * In older versions of EntityX, there were no guarantees around entity
-   * validity if a previously allocated entity slot was reassigned. That is no
-   * longer the case: if a slot is reassigned, old Entity::Id's will be
-   * invalid.
-   */
-  bool valid() const;
-
-  /**
-   * Invalidate Entity handle, disassociating it from an EntityManager and invalidating its ID.
-   *
-   * Note that this does *not* affect the underlying entity and its
-   * components. Use destroy() to destroy the associated Entity and components.
-   */
-  void invalidate();
-
-  Id id() const { return id_; }
-
-  template <typename C, typename ... Args>
-  ComponentHandle<C> assign(Args && ... args);
-
-  template <typename C>
-  ComponentHandle<C> assign_from_copy(const C &component);
-
-  template <typename C, typename ... Args>
-  ComponentHandle<C> replace(Args && ... args);
-
-  template <typename C>
-  void remove();
-
-  template <typename C, typename = typename std::enable_if<!std::is_const<C>::value>::type>
-  ComponentHandle<C> component();
-
-  template <typename C, typename = typename std::enable_if<std::is_const<C>::value>::type>
-  const ComponentHandle<C, const EntityManager> component() const;
-
-  template <typename ... Components>
-  std::tuple<ComponentHandle<Components>...> components();
-
-  template <typename ... Components>
-  std::tuple<ComponentHandle<const Components, const EntityManager>...> components() const;
-
-  template <typename C>
-  bool has_component() const;
-
-  template <typename A, typename ... Args>
-  void unpack(ComponentHandle<A> &a, ComponentHandle<Args> & ... args);
-
-  /**
-   * Destroy and invalidate this Entity.
-   */
-  void destroy();
-
-  std::bitset<entityx::MAX_COMPONENTS> component_mask() const;
-
- private:
-  EntityManager *manager_ = nullptr;
-  Entity::Id id_ = INVALID;
-};
-
-
-/**
- * A ComponentHandle<C> is a wrapper around an instance of a component.
- *
- * It provides safe access to components. The handle will be invalidated under
- * the following conditions:
- *
- * - If a component is removed from its host entity.
- * - If its host entity is destroyed.
- */
-template <typename C, typename EM>
-class ComponentHandle {
-public:
-  typedef C ComponentType;
-
-  ComponentHandle() : manager_(nullptr) {}
-
-  bool valid() const;
-  operator bool() const;
-
-  C *operator -> ();
-  const C *operator -> () const;
-
-  C *get();
-  const C *get() const;
-
-  /**
-   * Remove the component from its entity and destroy it.
-   */
-  void remove();
-
-  bool operator == (const ComponentHandle<C> &other) const {
-    return manager_ == other.manager_ && id_ == other.id_;
-  }
-
-  bool operator != (const ComponentHandle<C> &other) const {
-    return !(*this == other);
-  }
-
-private:
-  friend class EntityManager;
-
-  ComponentHandle(EM *manager, Entity::Id id) :
-      manager_(manager), id_(id) {}
-
-  EM *manager_;
-  Entity::Id id_;
-};
-
 
 /**
  * Base component class, only used for insertion into collections.

--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -384,7 +384,7 @@ class EntityManager : entityx::help::NonCopyable {
     for (size_t i = 0; i < component_pools_.size(); i++) {
       BasePool *pool = component_pools_[i];
       if (pool && mask.test(i)) {
-        pool->removeComponent(Entity(this, entity));
+        pool->remove_component(Entity(this, entity));
         pool->destroy(index);
       }
     }

--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -381,12 +381,14 @@ class EntityManager : entityx::help::NonCopyable {
     assert_valid(entity);
     uint32_t index = entity.index();
     auto mask = entity_component_mask_[entity.index()];
-    event_manager_.emit<EntityDestroyedEvent>(Entity(this, entity));
     for (size_t i = 0; i < component_pools_.size(); i++) {
       BasePool *pool = component_pools_[i];
-      if (pool && mask.test(i))
+      if (pool && mask.test(i)) {
+        pool->removeComponent(Entity(this, entity));
         pool->destroy(index);
+      }
     }
+    event_manager_.emit<EntityDestroyedEvent>(Entity(this, entity));
     entity_component_mask_[index].reset();
     entity_version_[index]++;
     free_list_.push_back(index);

--- a/entityx/EntityClass.h
+++ b/entityx/EntityClass.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2012 Alec Thomas <alec@swapoff.org>
+ * All rights reserved.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution.
+ *
+ * Author: Alec Thomas <alec@swapoff.org>
+ */
+
+#pragma once
+
+#include "entityx/config.h"
+
+namespace entityx {
+
+class EntityManager;
+
+template <typename C, typename EM = EntityManager>
+class ComponentHandle;
+
+/** A convenience handle around an Entity::Id.
+ *
+ * If an entity is destroyed, any copies will be invalidated. Use valid() to
+ * check for validity before using.
+ *
+ * Create entities with `EntityManager`:
+ *
+ *     Entity entity = entity_manager->create();
+ */
+class Entity {
+public:
+  struct Id {
+    Id() : id_(0) {}
+    explicit Id(uint64_t id) : id_(id) {}
+    Id(uint32_t index, uint32_t version) : id_(uint64_t(index) | uint64_t(version) << 32UL) {}
+
+    uint64_t id() const { return id_; }
+
+    bool operator == (const Id &other) const { return id_ == other.id_; }
+    bool operator != (const Id &other) const { return id_ != other.id_; }
+    bool operator < (const Id &other) const { return id_ < other.id_; }
+
+    uint32_t index() const { return id_ & 0xffffffffUL; }
+    uint32_t version() const { return id_ >> 32; }
+
+  private:
+    friend class EntityManager;
+
+    uint64_t id_;
+  };
+
+
+  /**
+   * Id of an invalid Entity.
+   */
+  static const Id INVALID;
+
+  Entity() = default;
+  Entity(EntityManager *manager, Entity::Id id) : manager_(manager), id_(id) {}
+  Entity(const Entity &other) = default;
+  Entity &operator = (const Entity &other) = default;
+
+  /**
+   * Check if Entity handle is invalid.
+   */
+  operator bool() const {
+    return valid();
+  }
+
+  bool operator == (const Entity &other) const {
+    return other.manager_ == manager_ && other.id_ == id_;
+  }
+
+  bool operator != (const Entity &other) const {
+    return !(other == *this);
+  }
+
+  bool operator < (const Entity &other) const {
+    return other.id_ < id_;
+  }
+
+  /**
+   * Is this Entity handle valid?
+   *
+   * In older versions of EntityX, there were no guarantees around entity
+   * validity if a previously allocated entity slot was reassigned. That is no
+   * longer the case: if a slot is reassigned, old Entity::Id's will be
+   * invalid.
+   */
+  bool valid() const;
+
+  /**
+   * Invalidate Entity handle, disassociating it from an EntityManager and invalidating its ID.
+   *
+   * Note that this does *not* affect the underlying entity and its
+   * components. Use destroy() to destroy the associated Entity and components.
+   */
+  void invalidate();
+
+  Id id() const { return id_; }
+
+  template <typename C, typename ... Args>
+  ComponentHandle<C> assign(Args && ... args);
+
+  template <typename C>
+  ComponentHandle<C> assign_from_copy(const C &component);
+
+  template <typename C, typename ... Args>
+  ComponentHandle<C> replace(Args && ... args);
+
+  template <typename C>
+  void remove();
+
+  template <typename C, typename = typename std::enable_if<!std::is_const<C>::value>::type>
+  ComponentHandle<C> component();
+
+  template <typename C, typename = typename std::enable_if<std::is_const<C>::value>::type>
+  const ComponentHandle<C, const EntityManager> component() const;
+
+  template <typename ... Components>
+  std::tuple<ComponentHandle<Components>...> components();
+
+  template <typename ... Components>
+  std::tuple<ComponentHandle<const Components, const EntityManager>...> components() const;
+
+  template <typename C>
+  bool has_component() const;
+
+  template <typename A, typename ... Args>
+  void unpack(ComponentHandle<A> &a, ComponentHandle<Args> & ... args);
+
+  /**
+   * Destroy and invalidate this Entity.
+   */
+  void destroy();
+
+  std::bitset<entityx::MAX_COMPONENTS> component_mask() const;
+
+ private:
+  EntityManager *manager_ = nullptr;
+  Entity::Id id_ = INVALID;
+};
+
+}

--- a/entityx/EntityClass.h
+++ b/entityx/EntityClass.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <bitset>
 #include "entityx/config.h"
 
 namespace entityx {

--- a/entityx/Entity_test.cc
+++ b/entityx/Entity_test.cc
@@ -405,6 +405,27 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentRemovedEvent") {
   REQUIRE(!(e.component<Direction>()));
 }
 
+TEST_CASE_METHOD(EntityManagerFixture, "TestComponentRemovedEventOnEntityDestroyed") {
+  struct ComponentRemovedReceiver : public Receiver<ComponentRemovedReceiver> {
+    void receive(const ComponentRemovedEvent<Direction> &event) {
+      removed = true;
+    }
+
+    bool removed = false;
+  };
+
+  ComponentRemovedReceiver receiver;
+  ev.subscribe<ComponentRemovedEvent<Direction>>(receiver);
+
+  REQUIRE(!(receiver.removed));
+
+  Entity e = em.create();
+  e.assign<Direction>(1.0, 2.0);
+  e.destroy();
+
+  REQUIRE(receiver.removed);
+}
+
 TEST_CASE_METHOD(EntityManagerFixture, "TestEntityAssignment") {
   Entity a, b;
   a = em.create();

--- a/entityx/help/Pool.h
+++ b/entityx/help/Pool.h
@@ -14,6 +14,8 @@
 #include <cassert>
 #include <vector>
 
+#include "entityx/EntityClass.h"
+
 namespace entityx {
 
 /**
@@ -63,6 +65,7 @@ class BasePool {
   }
 
   virtual void destroy(std::size_t n) = 0;
+  virtual void removeComponent(Entity entity) = 0;
 
  protected:
   std::vector<char *> blocks_;
@@ -89,6 +92,10 @@ class Pool : public BasePool {
     assert(n < size_);
     T *ptr = static_cast<T*>(get(n));
     ptr->~T();
+  }
+
+  virtual void removeComponent(Entity entity) override {
+    entity.remove<T>();
   }
 };
 

--- a/entityx/help/Pool.h
+++ b/entityx/help/Pool.h
@@ -65,7 +65,7 @@ class BasePool {
   }
 
   virtual void destroy(std::size_t n) = 0;
-  virtual void removeComponent(Entity entity) = 0;
+  virtual void remove_component(Entity entity) = 0;
 
  protected:
   std::vector<char *> blocks_;
@@ -94,7 +94,7 @@ class Pool : public BasePool {
     ptr->~T();
   }
 
-  virtual void removeComponent(Entity entity) override {
+  virtual void remove_component(Entity entity) override {
     entity.remove<T>();
   }
 };

--- a/entityx/help/Pool_test.cc
+++ b/entityx/help/Pool_test.cc
@@ -13,8 +13,9 @@
 #include <vector>
 #include "entityx/3rdparty/catch.hpp"
 #include "entityx/help/Pool.h"
+#include "entityx/Entity.h"
 
-struct Position {
+struct Position : public entityx::Component<Position> {
   explicit Position(int *ptr = nullptr) : ptr(ptr) {
     if (ptr) (*ptr)++;
   }

--- a/entityx/help/Pool_test.cc
+++ b/entityx/help/Pool_test.cc
@@ -15,7 +15,7 @@
 #include "entityx/help/Pool.h"
 #include "entityx/Entity.h"
 
-struct Position : public entityx::Component<Position> {
+struct Position {
   explicit Position(int *ptr = nullptr) : ptr(ptr) {
     if (ptr) (*ptr)++;
   }


### PR DESCRIPTION
This PR introduces the behavior of emitting a `ComponentRemovedEvent` for each of an `Entity`'s components when it is destroyed. This was discussed in #107.

This alters the behavior of the `EntityDestroyedEvent` since it made more sense to me to emit the  `ComponentRemovedEvent`s before the `EntityDestroyedEvent`, since that is similar to how a destructor would work. This change, of course, can be reverted.