### PR TITLE
Fixed shared library compilation and Function to retrieve the entity from ComponentHandle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,15 @@ macro(require FEATURE_NAME MESSAGE_STRING)
     endif()
 endmacro(require)
 
-macro(create_test TARGET_NAME SOURCE)
+macro(create_test TARGET_NAME SOURCE DEPENDENCIES)
     add_executable(${TARGET_NAME} ${SOURCE})
+    set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX -d)
+    set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "entityx/tests")
     target_link_libraries(
         ${TARGET_NAME}
-        entityx
+        ${DEPENDENCIES}
         ${ARGN}
         )
-    set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "entityx/tests")
 
     # Special case for benchmark tests
     if (${TARGET_NAME} MATCHES .*benchmark.*)
@@ -136,9 +137,7 @@ set(sources entityx/System.cc entityx/Event.cc entityx/Entity.cc entityx/help/Ti
 if (ENTITYX_BUILD_SHARED)
     message("-- Building shared libraries (-DENTITYX_BUILD_SHARED=0 to only build static librarires)")
     add_library(entityx_shared SHARED ${sources})
-    target_link_libraries(
-        entityx_shared
-        )
+
     set_target_properties(entityx_shared PROPERTIES
         OUTPUT_NAME entityx
         DEBUG_POSTFIX -d
@@ -154,13 +153,13 @@ endif (ENTITYX_BUILD_SHARED)
 
 if (ENTITYX_BUILD_TESTING)
     enable_testing()
-    create_test(pool_test entityx/help/Pool_test.cc)
-    create_test(entity_test entityx/Entity_test.cc)
-    create_test(event_test entityx/Event_test.cc)
-    create_test(system_test entityx/System_test.cc)
-    create_test(tags_component_test entityx/tags/TagsComponent_test.cc)
-    create_test(dependencies_test entityx/deps/Dependencies_test.cc)
-    create_test(benchmarks_test entityx/Benchmarks_test.cc)
+    create_test(pool_test entityx/help/Pool_test.cc ${install_libs})
+    create_test(entity_test entityx/Entity_test.cc ${install_libs})
+    create_test(event_test entityx/Event_test.cc ${install_libs})
+    create_test(system_test entityx/System_test.cc ${install_libs})
+    create_test(tags_component_test entityx/tags/TagsComponent_test.cc ${install_libs})
+    create_test(dependencies_test entityx/deps/Dependencies_test.cc ${install_libs})
+    create_test(benchmarks_test entityx/Benchmarks_test.cc ${install_libs})
     if (ENTITYX_RUN_BENCHMARKS)
         message("-- Running benchmarks")
     else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,9 @@ message("-- Checking misc features")
 require(HAVE_STDINT_H "stdint.h")
 
 # Things to install
-set(install_libs entityx)
+
 
 set(sources entityx/System.cc entityx/Event.cc entityx/Entity.cc entityx/help/Timer.cc entityx/help/Pool.cc)
-add_library(entityx STATIC ${sources})
-set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d FOLDER entityx)
 
 if (ENTITYX_BUILD_SHARED)
     message("-- Building shared libraries (-DENTITYX_BUILD_SHARED=0 to only build static librarires)")
@@ -147,7 +145,11 @@ if (ENTITYX_BUILD_SHARED)
         VERSION ${ENTITYX_VERSION}
         SOVERSION ${ENTITYX_MAJOR_VERSION}
         FOLDER entityx)
-    list(APPEND install_libs entityx_shared)
+	set(install_libs entityx_shared)
+else()
+	add_library(entityx STATIC ${sources})
+	set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d FOLDER entityx)
+	set(install_libs entityx)
 endif (ENTITYX_BUILD_SHARED)
 
 if (ENTITYX_BUILD_TESTING)
@@ -197,4 +199,5 @@ install(
     TARGETS ${install_libs}
     LIBRARY DESTINATION "${libdir}"
     ARCHIVE DESTINATION "${libdir}"
+	RUNTIME DESTINATION "bin"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ endmacro(require)
 
 macro(create_test TARGET_NAME SOURCE DEPENDENCIES)
     add_executable(${TARGET_NAME} ${SOURCE})
-    set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX -d)
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "entityx/tests")
     target_link_libraries(
         ${TARGET_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,9 @@ if (ENTITYX_BUILD_SHARED)
         FOLDER entityx)
 	set(install_libs entityx_shared)
 else()
-	add_library(entityx STATIC ${sources})
-	set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d FOLDER entityx)
-	set(install_libs entityx)
+    add_library(entityx STATIC ${sources})
+    set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d FOLDER entityx)
+    set(install_libs entityx)
 endif (ENTITYX_BUILD_SHARED)
 
 if (ENTITYX_BUILD_TESTING)
@@ -199,5 +199,5 @@ install(
     TARGETS ${install_libs}
     LIBRARY DESTINATION "${libdir}"
     ARCHIVE DESTINATION "${libdir}"
-	RUNTIME DESTINATION "bin"
+    RUNTIME DESTINATION "bin"
     )

--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -1044,7 +1044,7 @@ inline void ComponentHandle<C, EM>::remove() {
 template <typename C, typename EM>
 inline Entity ComponentHandle<C, EM>::entity() {
   assert(valid());
-  return manager_->template get(id_);
+  return manager_->get(id_);
 }
 
 

--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -201,6 +201,11 @@ public:
    */
   void remove();
 
+  /**
+   * Returns the Entity associated with the component
+   */
+  Entity entity();
+
   bool operator == (const ComponentHandle<C> &other) const {
     return manager_ == other.manager_ && id_ == other.id_;
   }
@@ -1034,6 +1039,12 @@ template <typename C, typename EM>
 inline void ComponentHandle<C, EM>::remove() {
   assert(valid());
   manager_->template remove<C>(id_);
+}
+
+template <typename C, typename EM>
+inline Entity ComponentHandle<C, EM>::entity() {
+  assert(valid());
+  return manager_->template get(id_);
 }
 
 


### PR DESCRIPTION
- Added a function to retrieve the Entity associated with a component in ComponentHandle.
- Fixed that when ENTITYX_BUILD_SHARED=1 was compiling the static library and the shared_library. Now it only compiles one of them, shared or static, but not both. Using visual studio compiler, now, the shared library doesn't create a .lib file (because it doesn't export anything which is OK).