### PR TITLE
CMake: Use 'STATUS' message type for non-error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(ENTITYX_VERSION ${ENTITYX_MAJOR_VERSION}.${ENTITYX_MINOR_VERSION}.${ENTITYX_
 
 project(EntityX)
 
-message("EntityX version ${ENTITYX_VERSION}")
+message(STATUS "EntityX version ${ENTITYX_VERSION}")
 
 if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH 0)
@@ -73,10 +73,10 @@ ENTITYX_HAVE_CXX11_STDLIB
 )
 
 if (NOT ENTITYX_HAVE_CXX11_STDLIB)
-    message("-- Not using -stdlib=libc++ (test failed to build)")
+    message(STATUS "-- Not using -stdlib=libc++ (test failed to build)")
     set(CMAKE_CXX_FLAGS "${OLD_CMAKE_CXX_FLAGS}")
 else ()
-    message("-- Using -stdlib=libc++")
+    message(STATUS "-- Using -stdlib=libc++")
 endif ()
 
 
@@ -87,7 +87,7 @@ macro(require FEATURE_NAME MESSAGE_STRING)
     if (NOT ${${FEATURE_NAME}})
         message(FATAL_ERROR "${MESSAGE_STRING} required -- ${${FEATURE_NAME}}")
     else()
-        message("--   ${MESSAGE_STRING} found")
+        message(STATUS "--   ${MESSAGE_STRING} found")
     endif()
 endmacro(require)
 
@@ -111,11 +111,11 @@ macro(create_test TARGET_NAME SOURCE DEPENDENCIES)
 endmacro()
 
 if (NOT CMAKE_BUILD_TYPE)
-    message("-- Defaulting to release build (use -DCMAKE_BUILD_TYPE:STRING=Debug for debug build)")
+    message(STATUS "-- Defaulting to release build (use -DCMAKE_BUILD_TYPE:STRING=Debug for debug build)")
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-message("-- Checking C++ features")
+message(STATUS "-- Checking C++ features")
 require(HAS_CXX11_AUTO "C++11 auto support")
 require(HAS_CXX11_NULLPTR "C++11 nullptr support")
 require(HAS_CXX11_RVALUE_REFERENCES "C++11 rvalue reference support")
@@ -125,7 +125,7 @@ require(HAS_CXX11_RVALUE_REFERENCES "C++11 rvalue references")
 require(HAS_CXX11_LONG_LONG "C++11 long long")
 require(HAS_CXX11_LONG_LONG "C++11 lambdas")
 
-message("-- Checking misc features")
+message(STATUS "-- Checking misc features")
 require(HAVE_STDINT_H "stdint.h")
 
 # Things to install
@@ -134,7 +134,7 @@ require(HAVE_STDINT_H "stdint.h")
 set(sources entityx/System.cc entityx/Event.cc entityx/Entity.cc entityx/help/Timer.cc entityx/help/Pool.cc)
 
 if (ENTITYX_BUILD_SHARED)
-    message("-- Building shared libraries (-DENTITYX_BUILD_SHARED=0 to only build static libraries)")
+    message(STATUS "-- Building shared libraries (-DENTITYX_BUILD_SHARED=0 to only build static libraries)")
     add_library(entityx_shared SHARED ${sources})
 
     set_target_properties(entityx_shared PROPERTIES
@@ -164,9 +164,9 @@ if (ENTITYX_BUILD_TESTING)
     create_test(dependencies_test entityx/deps/Dependencies_test.cc ${install_libs})
     create_test(benchmarks_test entityx/Benchmarks_test.cc ${install_libs})
     if (ENTITYX_RUN_BENCHMARKS)
-        message("-- Running benchmarks")
+        message(STATUS "-- Running benchmarks")
     else ()
-        message("-- Not running benchmarks (use -DENTITYX_RUN_BENCHMARKS=1 to enable)")
+        message(STATUS "-- Not running benchmarks (use -DENTITYX_RUN_BENCHMARKS=1 to enable)")
     endif ()
 endif (ENTITYX_BUILD_TESTING)
 


### PR DESCRIPTION
First, thank you for making entityx! I think it's a great library, easy to use and works very well. A few months ago, I started looking into the ECS approach for a new project, and was almost at the point where I considered creating my own implementation, but then I found entityx and it did everything I needed, so I went with it :)

This is a fairly minor cosmetic improvement, but I still find it useful, since I'm using cmake-gui a lot when developing on Windows. Prior to the changes in this branch, the output from cmake-gui would look like this:

![entityx-red](https://cloud.githubusercontent.com/assets/1821027/19828938/1f20d2de-9dd4-11e6-9748-bcd2eb3997ba.PNG)

When setting the `mode` to `STATUS` for the `message()` command, it instead looks like the following, which I believe is closer to how it's intended?

![entityx-regular](https://cloud.githubusercontent.com/assets/1821027/19828946/4c4d2596-9dd4-11e6-876d-3f1c5785cacb.PNG)

Note: I'm bundling entityx into my project using a submodule, instead of using it as an external library, which is why you see `boost` and `SDL` in the screenshots above.
