### PR TITLE
Mark EntityX::valid as const

### DIFF
--- a/entityx/entityx.hh
+++ b/entityx/entityx.hh
@@ -694,7 +694,7 @@ public:
   /**
    * Return true if the given entity ID is still valid.
    */
-  bool valid(Id id);
+  bool valid(Id id) const;
 
 
   /**
@@ -1081,7 +1081,7 @@ void EntityX<Components, Storage, Features>::reset() {
 
 
 template <class Components, class Storage, std::size_t Features>
-bool EntityX<Components, Storage, Features>::valid(Id id) {
+bool EntityX<Components, Storage, Features>::valid(Id id) const {
   return id.index() < entity_version_.size() && entity_version_[id.index()] == id.version();
 }
 


### PR DESCRIPTION
This allows `EntityX::valid` to be used in situations where we have (e.g.) a const reference to an entity manager.

I've verified that the example SFML 2 application and `entity_test` both compile and run/pass with this change.