### PR TITLE
Fix copy&paste mistake in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ require(HAS_CXX11_RVALUE_REFERENCES "C++11 rvalue reference support")
 require(HAS_CXX11_VARIADIC_TEMPLATES "C++11 variadic templates")
 require(HAS_CXX11_RVALUE_REFERENCES "C++11 rvalue references")
 require(HAS_CXX11_LONG_LONG "C++11 long long")
-require(HAS_CXX11_LONG_LONG "C++11 lambdas")
+require(HAS_CXX11_LAMBDA "C++11 lambdas")
 
 message(STATUS "-- Checking misc features")
 require(HAVE_STDINT_H "stdint.h")


### PR DESCRIPTION
A one-word fix in copy&paste mistake in the section for checking C++11 features.