### PR TITLE
Add dereference operator to ComponentHandle

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -193,6 +193,9 @@ public:
   C *operator -> ();
   const C *operator -> () const;
 
+  C &operator * ();
+  const C &operator * () const;
+
   C *get();
   const C *get() const;
 
@@ -1043,6 +1046,18 @@ template <typename C, typename EM>
 inline const C *ComponentHandle<C, EM>::operator -> () const {
   assert(valid());
   return manager_->template get_component_ptr<C>(id_);
+}
+
+template <typename C, typename EM>
+inline C &ComponentHandle<C, EM>::operator * () {
+  assert(valid());
+  return *manager_->template get_component_ptr<C>(id_);
+}
+
+template <typename C, typename EM>
+inline const C &ComponentHandle<C, EM>::operator * () const {
+  assert(valid());
+  return *manager_->template get_component_ptr<C>(id_);
 }
 
 template <typename C, typename EM>

--- a/entityx/Entity_test.cc
+++ b/entityx/Entity_test.cc
@@ -668,3 +668,13 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestViewEach") {
   });
   REQUIRE(count == 1);
 }
+
+TEST_CASE_METHOD(EntityManagerFixture, "TestComponentDereference") {
+  Entity a = em.create();
+  a.assign<Position>(10, 5);
+  auto& positionRef = *a.component<Position>();
+  REQUIRE(positionRef.x == 10);
+  REQUIRE(positionRef.y == 5);
+  positionRef.y = 20;
+  REQUIRE(a.component<Position>()->y == 20);
+}


### PR DESCRIPTION
This makes it possible to write code like this:

```cpp
auto& componentRef = *someEntity.component<Position>();
componentRef.x += 2;
```

This was already possible previously, but required calling `.get()` on the component handle in addition to dereferencing. Having this operator also makes the component handle more consistent with common smart pointer types, since it already has the `->` operator.

I wasn't sure whether it makes sense to add a test for something so trivial, but I did for now.