### PR TITLE
ADDED: for_each_component to Entity class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ int main() {
   position.remove();
   printf("has position = %d\n", bool(a.component<Position>()));
 
+  // Iterate over all components, in all entities that have a position component (good for serialization) ...
+  for (auto & entity : entities.entities_with_components<Position>()) {
+		entity.for_each_component([&entity](auto & component) {
+			// .... Do serialization...
+            // component.serialize();
+		});
+	}
 }
 ```
 

--- a/entityx/entityx.hh
+++ b/entityx/entityx.hh
@@ -241,6 +241,18 @@ struct Components {
     }
   }
 
+  template <class Storage, class F>
+  static void each(Storage &storage, const std::bitset<component_count> &mask, std::size_t index, F action) {
+	  Components::each<Storage, F, Cs...>(storage, mask, index, action);
+  }
+
+  template <class Storage, class F, class C>
+  static void each(Storage &storage, const std::bitset<component_count> &mask, std::size_t index, F action) {
+	  if (mask.test(component_index<C>::value)) {
+		  action(*storage.template get<C>(index));
+	  }
+  }
+
   template <class Storage, template <typename> class Component, typename ... Components>
   static std::tuple<Component<Cs> & ...> unpack(Storage &storage, std::size_t index, Component<Components> & ... components) {
     return std::forward_as_tuple(storage.template get<Components>(index)...);
@@ -262,6 +274,12 @@ private:
   static void destroy(Storage &storage, const std::bitset<component_count> &mask, std::size_t index) {
     Components::destroy<Storage, C>(storage, mask, index);
     Components::destroy<Storage, C1, Cn...>(storage, mask, index);
+  }
+
+  template <class Storage, class F, class C, class C1, class ... Cn>
+  static void each(Storage &storage, const std::bitset<component_count> &mask, std::size_t index, F action) {
+	  Components::each<Storage, F, C>(storage, mask, index, action);
+	  Components::each<Storage, F, C1, Cn...>(storage, mask, index, action);
   }
 };
 
@@ -484,6 +502,11 @@ public:
       invalidate();
     }
 
+	template<class F>
+	void for_each_component(F action) {
+		manager_->for_each_component(id_, action);
+	}
+
     ComponentMask component_mask() const {
       return manager_->component_mask(id_);
     }
@@ -690,6 +713,14 @@ public:
    * Emits EntityDestroyedEvent.
    */
   void destroy(Id entity);
+
+  /**
+  * iterate over all components of a given entity
+  *
+  * Does this work?
+  */
+  template<class F>
+  void for_each_component(Id entity, F action);
 
   /**
    * Return true if the given entity ID is still valid.
@@ -1048,6 +1079,15 @@ EntityX<Components, Storage, Features>::create_many(std::size_t count) {
   return entities;
 }
 
+
+
+
+template <class Components, class Storage, std::size_t Features>
+template <class F>
+inline void EntityX<Components, Storage, Features>::for_each_component(Id entity, F action) {
+	const std::uint32_t index = entity.index();
+	Components::template each<Storage>(storage_, entity_component_mask_[index], index, action);
+}
 
 
 


### PR DESCRIPTION
 Allows iterating over all entities with a given component. Requires C++14 generic lambdas for executing the iterator action. Useful for serializing batches of entity components generically - mainly using template based serialization libraries like cereal. This PR i used to then call my appropriate serialize() templates - this allowed for serializing entities anonymously in the compile_time branch. 

Side style choice note: I force the consumer to capture the entity on their own, to keep the actual arguments generic to the lambda. At the point the lambda is called, the entity has been decomposed to its component index, so I felt it better to not reconstruct the complete entity reference and force the consumer to capture it if so desired.

Requires C++14, which I know this branch does specifically - but also specifically requires C++ generic lambdas, which is *mostly* supported in VS2015 latest update (VS2017 for sure), but will break in older GCC releases and older MSVC patches. I figure this branch it doesn't matter much.

If this PR is of interest, I know entityx doesn't get much more advanced love these days - I have additional style changes across the classes (for_each lambda iterators, optimization of entity iteration, etc) I would love to push up to this branch if its considered still active 2.0 development.