### PR TITLE
Commented the assertion, as it prevents adding components to an entry…

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -641,7 +641,7 @@ class EntityManager : entityx::help::NonCopyable {
   ComponentHandle<C> assign(Entity::Id id, Args && ... args) {
     assert_valid(id);
     const BaseComponent::Family family = component_family<C>();
-    assert(!entity_component_mask_[id.index()].test(family));
+//    assert(!entity_component_mask_[id.index()].test(family));
 
     // Placement new into the component pool.
     Pool<C> *pool = accomodate_component<C>();


### PR DESCRIPTION
… in a loop of entities_with_components


When looping through entitites with entities_with_components, this assertion prevents the assignments to the entity. Such as this:

    ComponentHandle<Box> boxHandle;
    for (auto entity: entitiy_manager.entities_with_components(boxHandle))
    {
        entity.assign<BoxPosition>();
    }

It might be the design intention, but I wanted to create a pull request in case it isn't and I found the possible quick solution.
