### PR TITLE
Make ContiguousStorage deallocate on destruction

### DIFF
--- a/entityx/entityx.hh
+++ b/entityx/entityx.hh
@@ -204,6 +204,9 @@ public:
     resize(CHUNK_SIZE * INITIAL_CHUNKS);
   }
   ContiguousStorage(const ContiguousStorage &) = delete;
+  ~ContiguousStorage() {
+    reset();
+  }
 
   void resize(std::size_t n) {
     while (n > blocks_.size() * CHUNK_SIZE) {


### PR DESCRIPTION
Previously, ContiguousStorage did not deallocate on destruction and
would leak memory when an EntityManager was destructed.  An example
valgrind transcript on entity_test demonstrates this:

    $ valgrind --leak-check=full ./entity_test
    [...output elided...]
    ===============================================================================
    All tests passed (538 assertions in 28 test cases)

    ==21061==
    ==21061== HEAP SUMMARY:
    ==21061==     in use at exit: 1,600 bytes in 20 blocks
    ==21061==   total heap usage: 9,001 allocs, 8,981 frees, 54,582,761 bytes allocated
    ==21061==
    ==21061== 800 bytes in 10 blocks are definitely lost in loss record 1 of 2
    ==21061==    at 0x4C2D8CF: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==21061==    by 0x1332D9: resize (entityx.hh:210)
    ==21061==    by 0x1332D9: ContiguousStorage (entityx.hh:204)
    ==21061==    by 0x1332D9: ____C_A_T_C_H____T_E_S_T____531() (entity_test.cc:534)
    ==21061==    by 0x164DB5: invoke (catch.hh:6389)
    ==21061==    by 0x164DB5: runCurrentTest (catch.hh:5131)
    ==21061==    by 0x164DB5: runTest (catch.hh:5001)
    ==21061==    by 0x164DB5: Catch::Runner::runTests() (catch.hh:5275)
    ==21061==    by 0x12AA1F: run (catch.hh:5395)
    ==21061==    by 0x12AA1F: run (catch.hh:5378)
    ==21061==    by 0x12AA1F: main (catch.hh:8819)