### PR TITLE
Add missing argument in Entity::components() const

### DIFF
--- a/entityx/entityx.hh
+++ b/entityx/entityx.hh
@@ -403,7 +403,7 @@ public:
 
     template <typename ... Cn>
     std::tuple<const Cn*...> components() const {
-      return manager_->components<Cn...>();
+      return manager_->components<Cn...>(id_);
     }
 
     template <typename C, typename ... Args>

--- a/tests/entity_test.cc
+++ b/tests/entity_test.cc
@@ -488,6 +488,21 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityComponentsFromTuple") {
   REQUIRE(std::get<1>(components)->y == 4);
 }
 
+TEST_CASE_METHOD(EntityManagerFixture, "TestConstEntityComponentsFromTuple") {
+  Entity e = em.create();
+  e.assign<Position>(1,2);
+  e.assign<Direction>(3, 4);
+
+  const Entity& cref = e;
+
+  std::tuple<const Position*, const Direction*> components = cref.components<Position, Direction>();
+
+  REQUIRE(std::get<0>(components)->x == 1);
+  REQUIRE(std::get<0>(components)->y == 2);
+  REQUIRE(std::get<1>(components)->x == 3);
+  REQUIRE(std::get<1>(components)->y == 4);
+}
+
 TEST_CASE("TestComponentDestructorCalledWhenManagerDestroyed") {
   bool freed = false;
   {


### PR DESCRIPTION
`EntityX::components()` requires the entity ID in both its non-const and
const variants, but` Entity::components()` passed said ID in only one such
variant.

This commit also includes a test (almost identical to the existing
`Entity::components()` test) to exercise the compiler on this code path.