### PR TITLE
Update to brace initialisation to allow for easy aggregate use

### DIFF
--- a/entityx/Entity.h
+++ b/entityx/Entity.h
@@ -645,7 +645,7 @@ class EntityManager : entityx::help::NonCopyable {
 
     // Placement new into the component pool.
     Pool<C> *pool = accomodate_component<C>();
-    ::new(pool->get(id.index())) C(std::forward<Args>(args) ...);
+    ::new(pool->get(id.index())) C{std::forward<Args>(args) ...};
 
     // Set the bit for this component.
     entity_component_mask_[id.index()].set(family);
@@ -960,7 +960,7 @@ ComponentHandle<C> Entity::replace(Args && ... args) {
   assert(valid());
   auto handle = component<C>();
   if (handle) {
-    *(handle.get()) = C(std::forward<Args>(args) ...);
+    *(handle.get()) = C{std::forward<Args>(args) ...};
   } else {
     handle = manager_->assign<C>(id_, std::forward<Args>(args) ...);
   }

--- a/entityx/Entity_test.cc
+++ b/entityx/Entity_test.cc
@@ -142,7 +142,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityReuse") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentConstruction") {
   auto e = em.create();
-  auto p = e.assign<Position>(1, 2);
+  auto p = e.assign<Position>(1.f, 2.f);
   auto cp = e.component<Position>();
   REQUIRE(p ==  cp);
   REQUIRE(1.0 == Approx(cp->x));
@@ -257,8 +257,8 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestIterateAllEntitiesSkipsDestroyed") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestUnpack") {
   Entity e = em.create();
-  auto p = e.assign<Position>(1.0, 2.0);
-  auto d = e.assign<Direction>(3.0, 4.0);
+  auto p = e.assign<Position>(1.f, 2.f);
+  auto d = e.assign<Direction>(3.f, 4.f);
   auto t = e.assign<Tag>("tag");
 
   ComponentHandle<Position> up;
@@ -399,7 +399,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentRemovedEvent") {
 
   REQUIRE(!(receiver.removed));
   Entity e = em.create();
-  ComponentHandle<Direction> p = e.assign<Direction>(1.0, 2.0);
+  ComponentHandle<Direction> p = e.assign<Direction>(1.f, 2.f);
   e.remove<Direction>();
   REQUIRE(receiver.removed ==  p);
   REQUIRE(!(e.component<Direction>()));
@@ -420,7 +420,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentRemovedEventOnEntityDestroy
   REQUIRE(!(receiver.removed));
 
   Entity e = em.create();
-  e.assign<Direction>(1.0, 2.0);
+  e.assign<Direction>(1.f, 2.f);
   e.destroy();
 
   REQUIRE(receiver.removed);
@@ -474,7 +474,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityDestroyHole") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentHandleInvalidatedWhenEntityDestroyed") {
   Entity a = em.create();
-  ComponentHandle<Position> position = a.assign<Position>(1, 2);
+  ComponentHandle<Position> position = a.assign<Position>(1.f, 2.f);
   REQUIRE(position);
   REQUIRE(position->x == 1);
   REQUIRE(position->y == 2);
@@ -505,7 +505,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityCreateFromCopy") {
   Entity a = em.create();
   a.assign<CopyVerifier>();
   ComponentHandle<CopyVerifier> original = a.component<CopyVerifier>();
-  ComponentHandle<Position> aPosition = a.assign<Position>(1, 2);
+  ComponentHandle<Position> aPosition = a.assign<Position>(1.f, 2.f);
   Entity b = em.create_from_copy(a);
   ComponentHandle<CopyVerifier> copy = b.component<CopyVerifier>();
   ComponentHandle<Position> bPosition = b.component<Position>();
@@ -522,7 +522,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityCreateFromCopy") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentHandleInvalidatedWhenComponentDestroyed") {
   Entity a = em.create();
-  ComponentHandle<Position> position = a.assign<Position>(1, 2);
+  ComponentHandle<Position> position = a.assign<Position>(1.f, 2.f);
   REQUIRE(position);
   REQUIRE(position->x == 1);
   REQUIRE(position->y == 2);
@@ -532,7 +532,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentHandleInvalidatedWhenCompon
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestDeleteEntityWithNoComponents") {
   Entity a = em.create();
-  a.assign<Position>(1, 2);
+  a.assign<Position>(1.f, 2.f);
   Entity b = em.create();
   b.destroy();
 }
@@ -562,8 +562,8 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityInStdMap") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestEntityComponentsFromTuple") {
   Entity e = em.create();
-  e.assign<Position>(1, 2);
-  e.assign<Direction>(3, 4);
+  e.assign<Position>(1.f, 2.f);
+  e.assign<Direction>(3.f, 4.f);
 
   std::tuple<ComponentHandle<Position>, ComponentHandle<Direction>> components = e.components<Position, Direction>();
 
@@ -622,7 +622,7 @@ TEST_CASE("TestComponentDestructorCalledWhenEntityDestroyed") {
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentsRemovedFromReusedEntities") {
   Entity a = em.create();
   Entity::Id aid = a.id();
-  a.assign<Position>(1, 2);
+  a.assign<Position>(1.f, 2.f);
   a.destroy();
 
   Entity b = em.create();
@@ -630,12 +630,12 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestComponentsRemovedFromReusedEntities"
 
   REQUIRE(aid.index() == bid.index());
   REQUIRE(!b.has_component<Position>());
-  b.assign<Position>(3, 4);
+  b.assign<Position>(3.f, 4.f);
 }
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestConstComponentsNotInstantiatedTwice") {
   Entity a = em.create();
-  a.assign<Position>(1, 2);
+  a.assign<Position>(1.f, 2.f);
 
   const Entity b = a;
 
@@ -647,7 +647,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestConstComponentsNotInstantiatedTwice"
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestEntityManagerEach") {
   Entity a = em.create();
-  a.assign<Position>(1, 2);
+  a.assign<Position>(1.f, 2.f);
   int count = 0;
   em.each<Position>([&count](Entity entity, Position &position) {
     count++;
@@ -659,7 +659,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestEntityManagerEach") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestViewEach") {
   Entity a = em.create();
-  a.assign<Position>(1, 2);
+  a.assign<Position>(1.f, 2.f);
   int count = 0;
   em.entities_with_components<Position>().each([&count](Entity entity, Position &position) {
     count++;
@@ -671,7 +671,7 @@ TEST_CASE_METHOD(EntityManagerFixture, "TestViewEach") {
 
 TEST_CASE_METHOD(EntityManagerFixture, "TestComponentDereference") {
   Entity a = em.create();
-  a.assign<Position>(10, 5);
+  a.assign<Position>(10.f, 5.f);
   auto& positionRef = *a.component<Position>();
   REQUIRE(positionRef.x == 10);
   REQUIRE(positionRef.y == 5);

--- a/entityx/Event.h
+++ b/entityx/Event.h
@@ -180,7 +180,7 @@ class EventManager : entityx::help::NonCopyable {
   template <typename E, typename ... Args>
   void emit(Args && ... args) {
     // Using 'E event(std::forward...)' causes VS to fail with an internal error. Hack around it.
-    E event = E(std::forward<Args>(args) ...);
+    E event = E{std::forward<Args>(args) ...};
     auto sig = signal_for(std::size_t(Event<E>::family()));
     sig->emit(&event);
   }

--- a/entityx/System.h
+++ b/entityx/System.h
@@ -118,7 +118,7 @@ class SystemManager : entityx::help::NonCopyable {
    */
   template <typename S, typename ... Args>
   std::shared_ptr<S> add(Args && ... args) {
-    std::shared_ptr<S> s(new S(std::forward<Args>(args) ...));
+    std::shared_ptr<S> s(new S{std::forward<Args>(args) ...});
     add(s);
     return s;
   }

--- a/entityx/System_test.cc
+++ b/entityx/System_test.cc
@@ -76,8 +76,8 @@ class EntitiesFixture : public EntityX {
     for (int i = 0; i < 150; ++i) {
       Entity e = entities.create();
       created_entities.push_back(e);
-      if (i % 2 == 0) e.assign<Position>(1, 2);
-      if (i % 3 == 0) e.assign<Direction>(1, 1);
+      if (i % 2 == 0) e.assign<Position>(1.f, 2.f);
+      if (i % 3 == 0) e.assign<Direction>(1.f, 1.f);
 
       e.assign<Counter>(0);
     }


### PR DESCRIPTION
As discussed in #212, update relevant initialisation locations to use `{}` instead of `()`. Also updated tests to pass the right types to avoid narrowing conversion errors.