### PR TITLE
fix windows vs2019 compile error "can not find entityx.lib" -> build static lib by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(ENTITYX_BUILD_TESTING true CACHE BOOL "Enable building of tests.")
 set(ENTITYX_RUN_BENCHMARKS false CACHE BOOL "Run benchmarks (in conjunction with -DENTITYX_BUILD_TESTING=1).")
 set(ENTITYX_MAX_COMPONENTS 64 CACHE STRING "Set the maximum number of components.")
 set(ENTITYX_DT_TYPE double CACHE STRING "The type used for delta time in EntityX update methods.")
-set(ENTITYX_BUILD_SHARED true CACHE BOOL "Build shared libraries?")
+set(ENTITYX_BUILD_SHARED false CACHE BOOL "Build shared libraries?")
 
 include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
 include(CheckCXXSourceCompiles)


### PR DESCRIPTION
Don't know whether it is right. I didn't check other platform