### PR TITLE
Make debug postfix optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ require(HAVE_STDINT_H "stdint.h")
 
 # Things to install
 
+if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX "-d")
+endif()
 
 set(sources entityx/System.cc entityx/Event.cc entityx/Entity.cc entityx/help/Timer.cc entityx/help/Pool.cc)
 
@@ -127,7 +130,7 @@ if (ENTITYX_BUILD_SHARED)
 
     set_target_properties(entityx PROPERTIES
         OUTPUT_NAME entityx
-        DEBUG_POSTFIX -d
+        DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}"
         VERSION ${ENTITYX_VERSION}
         SOVERSION ${ENTITYX_MAJOR_VERSION}
         FOLDER entityx)
@@ -136,7 +139,9 @@ if (ENTITYX_BUILD_SHARED)
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 else()
     add_library(entityx STATIC ${sources})
-    set_target_properties(entityx PROPERTIES DEBUG_POSTFIX -d FOLDER entityx)
+    set_target_properties(entityx PROPERTIES 
+        DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}"
+        FOLDER entityx)
     set(install_libs entityx)
     set_property(TARGET entityx APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
Library debug postfix might not be suitable for cross platform project, and usually require extra work of link against prebuilt entityx.

Generally, Xcode project output library to these directories:
```
    Debug
    Release
    Debug-iphoneos
    Release-iphoneos
    Debug-iphonesimulator
    Release-iphonesimulator
```
Another Xcode project usually configured its build setting as follow, and expects library name to be same between Release and Debug
```
    LIBRARY_SEARCH_PATHS=$(CONFIGURATION)$(EFFECT_PLATFORM_NAME)
    OTHER_LDFLAGS= $(inherited) -lentityx
```