### PR TITLE
Add warning for unsupported configuration in MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ set(ENTITYX_BUILD_SHARED true CACHE BOOL "Build shared libraries?")
 include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
 include(CheckCXXSourceCompiles)
 
+if(ENTITYX_BUILD_SHARED AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    message(WARNING "\nBuilding as a shared library with MSVC is currently unsupported \
+        and will not function as expected.\
+        \nUse -DENTITYX_BUILD_SHARED=FALSE to build as a static library.")
+endif()
+
 # Default compiler args
 if (CMAKE_CXX_COMPILER_ID MATCHES "(GNU|.*Clang)")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wall -Wextra -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=sign-compare")


### PR DESCRIPTION
This addresses the potential silent failure of attempting to build EntityX as a shared library with MSVC, seen in #160, #186, #206, #246, and others.  It is expressed as a warning instead of a fatal error to permit the "workaround" found in multiple comments on those issues.  

With this warning emitted at configuration-time, it is made clear to the end-user that this is an unsupported option on their platform, saving potential time and effort diagnosing the issue or reporting it as a bug.